### PR TITLE
Feature: Support command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@ It uses [Actions-Toolkit](https://github.com/JasonEtco/actions-toolkit) by [@Jas
 1. Create `.github/stale.yml` based on the following template.
 2. Create a `main.workflow` based off the [`example.workflow`](./example.workflow) in this repository, which will start a scan in response to a [`repository_dispatch`](https://developer.github.com/actions/creating-workflows/triggering-a-repositorydispatch-webhook/) event.
 
-A `.github/stale.yml` file is required to enable the plugin. The file can be empty, or it can override any of these default settings:
+To customize how the action will run, you can provide options in one of the following ways:
+
+#### Command line arguments
+Any of the supported options below can be passed as command line flags directly in the Actions editor. As an example, you can configure your workflow as follows:
+
+```hcl
+workflow "Run Stale!" {
+  on = "repository_dispatch"
+  resolves = ["probot/stale-action"]
+}
+
+action "probot/stale-action" {
+  uses = "probot/stale-action@master"
+  secrets = ["GITHUB_TOKEN"]
+  args = "type:issues --daysUntilStale 30 --daysUntilClose 60 --staleLabel wontfix"
+}
+```
+
+#### A `.github/stale.yml` file in your repository.
+The file can be empty, or it can override any of these default settings:
 
 ```yml
 # Configuration for probot-stale - https://github.com/probot/stale

--- a/index.js
+++ b/index.js
@@ -23,7 +23,17 @@ module.exports = async tools => {
   tools.log.pending('Retrieving Stale config from `.github/stale.yml`...')
   const config = tools.config('.github/stale.yml')
 
-  if (tools.context.event === 'repository_dispatch') {
+  const sweepEvent = (event) => {
+    switch (event) {
+      case 'repository_dispatch':
+        return true
+      case 'schedule':
+        return true
+      default:
+        return false
+    }
+  }
+  if (sweepEvent(tools.context.event)) {
     const stale = new Stale(tools, config)
     const type = tools.context.payload.issue ? 'issues' : 'pulls'
     stale.markAndSweep(type).then(() => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -45,11 +45,11 @@ describe('handle-stale-action', () => {
     const mockMarkAndSweep = require('../lib/stale').prototype.markAndSweep = jest.fn().mockResolvedValue(true)
     const tools = mockToolkit('repository_dispatch', 'repository-dispatch')
 
-    runAction(tools)
+    await runAction(tools)
 
     await mockMarkAndSweep()
 
-    expect(tools.log.success).toBeCalledWith('Done with mark and sweep!')
+    expect(tools.log.success).toBeCalled()
     expect(tools.log.success.mock.calls).toMatchSnapshot()
   })
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -111,6 +111,21 @@ describe('handle-stale-action', () => {
     expect(tools.exit.neutral).toBeCalled()
     await done()
   })
+
+  it('supports arguments for options', async () => {
+    const mockMarkAndSweep = require('../lib/stale').prototype.markAndSweep = jest.fn().mockResolvedValue(true)
+    const { buildConfig } = require('../')
+
+    const tools = mockToolkit('repository_dispatch', 'repository-dispatch')
+    tools.arguments = { _: ['issues'], daysUntilClose: 25 }
+
+    const config = buildConfig(tools)
+
+    await runAction(tools)
+
+    expect(config.daysUntilClose).toBe(25)
+    expect(mockMarkAndSweep).toBeCalledWith('issues')
+  })
 })
 
 module.exports = mockToolkit


### PR DESCRIPTION
It may be preferred in some scenarios not to have to be required to add a `stale.yml` to your repository and it feels a bit nicer not to have to add both that and a `main.workflow` just to get started. This will add support for passing config options as a command line flag in addition to an option to choose to separately scan issues or pull requests. Command line flags will override both default options as well as anything defined in `github/stale.yml` if you choose to use both. This way you can define some of the more complicated settings in the repository and override just a few of them with arguments.

Need to do some more testing of this, but so far it seems to work pretty well for `daysUntilClose` and `daysUntilStale`.

cc @JasonEtco 